### PR TITLE
Updated to latest stable kotlin version and latest stable velocity release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,12 @@ plugins {
   kotlin("kapt")
   kotlin("plugin.serialization")
   id("com.github.johnrengelman.shadow")
+  `maven-publish`
 }
 
 val kotlinVersion: String by project
 val velocityVersion: String by project
+val coroutinesVersion: String by project
 
 group = "com.velocitypowered"
 version = "$velocityVersion+$kotlinVersion"
@@ -15,15 +17,16 @@ repositories {
   mavenLocal()
   mavenCentral()
 
-  maven("https://repo.velocitypowered.com/snapshots/")
+  maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {
   implementation(kotlin("reflect"))
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinVersion")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinVersion")
-  implementation("net.kyori:adventure-extra-kotlin:4.9.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
+  api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:$coroutinesVersion"))
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion")
+  implementation("net.kyori:adventure-extra-kotlin:4.10.1")
 
   compileOnly("com.velocitypowered:velocity-api:$velocityVersion")
   kapt("com.velocitypowered:velocity-api:$velocityVersion")
@@ -31,4 +34,31 @@ dependencies {
 
 tasks.build {
   dependsOn(tasks.shadowJar.get())
+  dependsOn("generateTemplates")
+}
+
+val templateSource = file("src/main/templates")
+val templateDest = layout.buildDirectory.dir("generated/sources/templates")
+tasks.create<Copy>("generateTemplates") {
+  val props = mapOf(
+    "version" to project.version
+  )
+  inputs.properties(props)
+  from(templateSource)
+  into(templateDest)
+  expand(props)
+}
+
+sourceSets.main {
+  java {
+    srcDir(templateDest)
+  }
+}
+
+publishing {
+  publications {
+    create<MavenPublication>("mavenJava") {
+      artifact(tasks.shadowJar.get())
+    }
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 kotlin.code.style=official
 
-kotlinVersion=1.5.31
-velocityVersion=3.0.0-SNAPSHOT
+kotlinVersion=1.6.21
+coroutinesVersion=1.6.1-native-mt
+velocityVersion=3.1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/velocitypowered/api/kt/VelocityPlugin.kt
+++ b/src/main/kotlin/com/velocitypowered/api/kt/VelocityPlugin.kt
@@ -9,11 +9,11 @@ import com.velocitypowered.api.kt.event.registerCoroutineContinuationAdapter
 import com.velocitypowered.api.plugin.Plugin
 import org.slf4j.Logger
 
-@Plugin(id = "velocity-language-kotlin", authors = ["Velocity Contributors"])
+@Plugin(id = "velocity-language-kotlin", authors = ["Velocity Contributors"], version = BuildConstants.VERSION)
 @Suppress("unused")
 class VelocityPlugin @Inject constructor(
   val logger: Logger,
-  val eventManager: EventManager,
+  eventManager: EventManager,
 ) {
 
   init {

--- a/src/main/templates/com/velocitypowered/api/kt/BuildConstants.kt
+++ b/src/main/templates/com/velocitypowered/api/kt/BuildConstants.kt
@@ -1,0 +1,5 @@
+package com.velocitypowered.api.kt
+
+object BuildConstants {
+  const val VERSION = "${version}"
+}


### PR DESCRIPTION
Hello, I've updated the provided Kotlin version to 1.6.21 and the used velocity API version to 3.1.1 (latest 3.x.x stable release).
Also, I added a template for the version, that gets filled out by Gradle, to get rid of the unknown version on startup.

I've put it into a separate branch, as the 3.0.0 branch is locked to that version, if I got that right.

Please create a new branch and merge it to the new one, I don't know if it's possible to create a pull request for a new branch.